### PR TITLE
Add MAJOR_VERSION_TAG_ONLY variable to tag only the major versions #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ It works well for GitHub Action. ref: https://help.github.com/en/articles/about-
 
 **Optional**. Tag message. Default: `Release $TAG`
 
+### `major_version_tag_only`
+
+**Optional**. Create only major version tags. Default: `false`
+
 ## Example usage
 
 ### [.github/workflows/update_semver.yml](.github/workflows/update_semver.yml)
@@ -41,6 +45,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: haya14busa/action-update-semver@v1
         with:
+          major_version_tag_only: true  # (optional, default is "false")
           github_token: ${{ secrets.github_token }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   message:
     description: 'Tag message.'
     required: false
+  major_version_tag_only:
+    description: 'Optional. Create only major version tags.'
+    required: false
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 set -x
 
-cd "${GITHUB_WORKSPACE}"
+cd "${GITHUB_WORKSPACE}" || exit
 
 # Set up variables.
 TAG="${INPUT_TAG:-${GITHUB_REF#refs/tags/}}" # v1.2.3
 MINOR="${TAG%.*}"                            # v1.2
 MAJOR="${MINOR%.*}"                          # v1
+MAJOR_VERSION_TAG_ONLY=${INPUT_MAJOR_VERSION_TAG_ONLY:-}
 
 if [ "${GITHUB_REF}" = "${TAG}" ]; then
   echo "This workflow is not triggered by tag push: GITHUB_REF=${GITHUB_REF}"
@@ -20,10 +21,10 @@ git config user.name "${GITHUB_ACTOR}"
 git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
 # Update MAJOR/MINOR tag
-git tag -fa ${MAJOR} -m "${MESSAGE}"
-git tag -fa ${MINOR} -m "${MESSAGE}"
+git tag -fa "${MAJOR}" -m "${MESSAGE}"
+[ "${MAJOR_VERSION_TAG_ONLY}" = "true" ] || [ "${MAJOR_VERSION_TAG_ONLY}" = "yes" ] && git tag -fa "${MINOR}" -m "${MESSAGE}"
 
 # Push
-git remote set-url origin https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-git push --force origin ${MINOR}
-git push --force origin ${MAJOR}
+git remote set-url origin "https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+[ "${MAJOR_VERSION_TAG_ONLY}" = "true" ] || [ "${MAJOR_VERSION_TAG_ONLY}" = "yes" ] git push --force origin "${MINOR}"
+git push --force origin "${MAJOR}"


### PR DESCRIPTION
* Add MAJOR_VERSION_TAG_ONLY variable to tag only the major versions #2
* `entrypoint.sh` modified to pass shellcheck