### PR TITLE
Adds the ability to also move the tag that triggered the workflow (explicit)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#cbc9c5",
+        "activityBar.activeBorder": "#308f70",
+        "activityBar.background": "#cbc9c5",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#308f70",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "tab.activeBorder": "#cbc9c5",
+        "titleBar.activeBackground": "#b3b0aa",
+        "titleBar.activeForeground": "#15202b",
+        "titleBar.inactiveBackground": "#b3b0aa99",
+        "titleBar.inactiveForeground": "#15202b99"
+    },
+    "peacock.color": "#b3b0aa"
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This action updates major/minor release tags on a tag push.
 e.g. Update `v1` and `v1.2` tag when released `v1.2.3`.
 
-It works well for GitHub Action. ref: https://help.github.com/en/articles/about-actions#versioning-your-action
+It works well for GitHub Action. ref: <https://help.github.com/en/articles/about-actions#versioning-your-action>
 
 ## Inputs
 
@@ -24,11 +24,14 @@ It works well for GitHub Action. ref: https://help.github.com/en/articles/about-
 
 **Optional**. Create only major version tags. Default: `false`
 
+### `move_patch_tag`
+
+**Optional**. Moves the existing tag to the latest commit inside the github action. Default: `false`. Useful when you for example want to add a changelog to your tagged version.
+
 ### `github_token`
 
 **Optional**. It's no need to specify it if you use checkout@v2. Required for
 checkout@v1 action.
-
 
 ## Example usage
 
@@ -56,24 +59,22 @@ jobs:
 
 <summary>oneliner</summary>
 
-```
-$ cat <<EOF > .github/workflows/update_semver.yml
-name: Update Semver
-on:
-  push:
-    branches-ignore:
-      - '**'
-    tags:
-      - 'v*.*.*'
-jobs:
-  update-semver:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: haya14busa/action-update-semver@v1
-        with:
-          github_token: \${{ secrets.github_token }}
-EOF
-```
+    $ cat <<EOF > .github/workflows/update_semver.yml
+    name: Update Semver
+    on:
+      push:
+        branches-ignore:
+          - '**'
+        tags:
+          - 'v*.*.*'
+    jobs:
+      update-semver:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v1
+          - uses: haya14busa/action-update-semver@v1
+            with:
+              github_token: \${{ secrets.github_token }}
+    EOF
 
 </details>

--- a/action.yml
+++ b/action.yml
@@ -1,24 +1,27 @@
-name: 'Update major/minor semver'
-description: 'Updates major/minor release tags on a tag push'
-author: 'haya14busa'
+name: "Update major/minor semver"
+description: "Updates major/minor release tags on a tag push"
+author: "haya14busa"
 inputs:
   github_token:
-    description: 'GITHUB_TOKEN. Optional if you use checkout@v2 action.'
-    default: '${{ github.token }}'
+    description: "GITHUB_TOKEN. Optional if you use checkout@v2 action."
+    default: "${{ github.token }}"
   tag:
-    description: 'Optional. Existing tag to update from. Default comes from $GITHUB_REF.'
+    description: "Optional. Existing tag to update from. Default comes from $GITHUB_REF."
     required: false
   message:
-    description: 'Tag message.'
+    description: "Tag message."
     required: false
   major_version_tag_only:
-    description: 'Optional. Create only major version tags.'
+    description: "Optional. Create only major version tags."
+    required: false
+  move_patch_tag:
+    description: "Optional. Move the patch tag to the latest commit."
     required: false
 
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 # Ref: https://haya14busa.github.io/github-action-brandings/
 branding:
-  icon: 'refresh-cw'
-  color: 'green'
+  icon: "refresh-cw"
+  color: "green"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ TAG="${INPUT_TAG:-${GITHUB_REF#refs/tags/}}" # v1.2.3
 MINOR="${TAG%.*}"                            # v1.2
 MAJOR="${MINOR%.*}"                          # v1
 MAJOR_VERSION_TAG_ONLY=${INPUT_MAJOR_VERSION_TAG_ONLY:-}
+MOVE_PATCH_TAG=${INPUT_MOVE_PATCH_TAG:-}
 
 if [ "${GITHUB_REF}" = "${TAG}" ]; then
   echo "This workflow is not triggered by tag push: GITHUB_REF=${GITHUB_REF}"
@@ -23,6 +24,7 @@ git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 # Update MAJOR/MINOR tag
 git tag -fa "${MAJOR}" -m "${MESSAGE}"
 [ "${MAJOR_VERSION_TAG_ONLY}" = "true" ] || git tag -fa "${MINOR}" -m "${MESSAGE}"
+[ "${MOVE_PATCH_TAG}" = "true" ] || git tag -fa "${TAG}" -m "${MESSAGE}"
 
 # Set up remote url for checkout@v1 action.
 if [ -n "${INPUT_GITHUB_TOKEN}" ]; then
@@ -31,4 +33,5 @@ fi
 
 # Push
 [ "${MAJOR_VERSION_TAG_ONLY}" = "true" ] || git push --force origin "${MINOR}"
+[ "${MOVE_PATCH_TAG}" = "true" ] || git push --force origin "${TAG}"
 git push --force origin "${MAJOR}"


### PR DESCRIPTION
Just a heads up, In my fork I made a minor change which also causes the tag that triggered the workflow to update to the latest commit on the checkout branch. I needed this feature since I'm committing a changelog with each tagged release and would like to retag the release to this changelog such that it is included in the release. In the upstream version, the triggered tag will stay on the commit that triggers the workflow while the major and minor tags are now on the latest commit. I understand that this might be a bit of a edge case so feel free to close this pull request. Might you think it is a great addition I created both a implicit and explicit version of this feature.