### PR TITLE
remove github_token altogether

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag haya14busa-action-update-semver:$(date +%s)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ It works well for GitHub Action. ref: https://help.github.com/en/articles/about-
 
 **Optional**. Create only major version tags. Default: `false`
 
-### `github_token`
-
-**Optional**. It's no need to specify it if you use checkout@v2. Required for
-checkout@v1 action.
-
 
 ## Example usage
 
@@ -69,10 +64,8 @@ jobs:
   update-semver:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: haya14busa/action-update-semver@v1
-        with:
-          github_token: \${{ secrets.github_token }}
 EOF
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,6 @@ name: 'Update major/minor semver'
 description: 'Updates major/minor release tags on a tag push'
 author: 'haya14busa'
 inputs:
-  github_token:
-    description: 'GITHUB_TOKEN. Optional if you use checkout@v2 action.'
-    default: '${{ github.token }}'
   tag:
     description: 'Optional. Existing tag to update from. Default comes from $GITHUB_REF.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,11 +24,6 @@ git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 git tag -fa "${MAJOR}" -m "${MESSAGE}"
 [ "${MAJOR_VERSION_TAG_ONLY}" = "true" ] || git tag -fa "${MINOR}" -m "${MESSAGE}"
 
-# Set up remote url for checkout@v1 action.
-if [ -n "${INPUT_GITHUB_TOKEN}" ]; then
-  git remote set-url origin "https://${GITHUB_ACTOR}:${INPUT_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-fi
-
 # Push
 [ "${MAJOR_VERSION_TAG_ONLY}" = "true" ] || git push --force origin "${MINOR}"
 git push --force origin "${MAJOR}"


### PR DESCRIPTION
this is kinda followup to #12 because I found that it would still receive the input, and because it is hardcoded to github.com it would not work on a GHES instance.