### PR TITLE
feat: Add major and minor tag outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,19 @@ inputs:
     description: 'Optional. Create only major version tags.'
     required: false
 
+outputs:
+  major:
+    description: 'The major version tag (e.g., v1)'
+    value: ${{ steps.update-tags.outputs.major }}
+  minor:
+    description: 'The minor version tag (e.g., v1.2)'
+    value: ${{ steps.update-tags.outputs.minor }}
+
 runs:
   using: 'composite'
   steps:
     - name: Update major/minor semver tags
+      id: update-tags
       shell: bash
       env:
         INPUT_TAG: ${{ inputs.tag }}

--- a/script.sh
+++ b/script.sh
@@ -32,3 +32,7 @@ fi
 # Push
 [ "${MAJOR_VERSION_TAG_ONLY}" = "true" ] || git push --force origin "${MINOR}"
 git push --force origin "${MAJOR}"
+
+# Set outputs for GitHub Actions
+echo "major=${MAJOR}" >> "${GITHUB_OUTPUT}"
+[ "${MAJOR_VERSION_TAG_ONLY}" = "true" ] || echo "minor=${MINOR}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- Add `major` and `minor` outputs to the action that return the version tag strings
- This allows workflows to use the generated tags in subsequent steps

## Test plan
- [ ] Test that the action correctly outputs major tag (e.g., `v1`)
- [ ] Test that the action correctly outputs minor tag (e.g., `v1.2`)
- [ ] Verify that `major_version_tag_only` option still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)